### PR TITLE
make keys case-insensitive (keyword.other.name)

### DIFF
--- a/Syntax Definitions/Sublime Settings.JSON-tmLanguage
+++ b/Syntax Definitions/Sublime Settings.JSON-tmLanguage
@@ -9,7 +9,7 @@
       "begin": "/\\*",
       "end": "\\*/"
     },
-    {  "match": "\"([a-z0-9_.*-]+)\"\\s*?:",
+    {  "match": "(?i)\"([a-z0-9_.*-]+)\"\\s*?:",
        "captures": {
            "1": { "name": "keyword.other.name.sublime-settings" }
        }

--- a/Syntax Definitions/Sublime Settings.tmLanguage
+++ b/Syntax Definitions/Sublime Settings.tmLanguage
@@ -34,7 +34,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>"([a-z0-9_.*-]+)"\s*?:</string>
+			<string>"(?i)([a-z0-9_.*-]+)"\s*?:</string>
 		</dict>
 		<dict>
 			<key>include</key>


### PR DESCRIPTION
Not much to say - just added `(?i)` at the beginning of the regex to make it case-insensitive, as some plugins use camelCase in their key names.